### PR TITLE
Backup status monitor

### DIFF
--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -42,6 +42,7 @@ function row() {
     local s=$2
     local n=$3
     local c=$4
+    local o=$5
     local space='                            '
     local tcls=''
     if [[ "${s}" == "COMPLETE" ]]; then
@@ -55,25 +56,25 @@ function row() {
     elif [[ "${s}" == "NO CONFIGURATION" ]]; then
         tcls='danger'
     else
-        echo 'Unknown status!'
+        echo 'Unknown status!' >&2
         return
     fi
-    echo "${space}<tr>"
-    echo "${space}    <td>${d}/</td>"
-    echo "${space}    <td class=\"table-${tcls}\"><strong>${s}</strong></td>"
+    echo "${space}<tr>" >> ${o}
+    echo "${space}    <td>${d}/</td>" >> ${o}
+    echo "${space}    <td class=\"table-${tcls}\"><strong>${s}</strong></td>" >> ${o}
     if [[ "${n}" == "False" ]]; then
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">CSV</a></td>"
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">TXT</a></td>"
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">JSON</a></td>"
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">LOG</a></td>"
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">CSV</a></td>" >> ${o}
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">TXT</a></td>" >> ${o}
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">JSON</a></td>" >> ${o}
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">LOG</a></td>" >> ${o}
     else
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"disk_files_${d}.csv\" title=\"disk_files_${d}.csv\">CSV</a></td>"
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"hpss_files_${d}.txt\" title=\"hpss_files_${d}.txt\">TXT</a></td>"
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"missing_files_${d}.json\" title=\"missing_files_${d}.json\">JSON</a></td>"
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"missing_files_${d}.log\" title=\"missing_files_${d}.log\">LOG</a></td>"
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"disk_files_${d}.csv\" title=\"disk_files_${d}.csv\">CSV</a></td>" >> ${o}
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"hpss_files_${d}.txt\" title=\"hpss_files_${d}.txt\">TXT</a></td>" >> ${o}
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"missing_files_${d}.json\" title=\"missing_files_${d}.json\">JSON</a></td>" >> ${o}
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"missing_files_${d}.log\" title=\"missing_files_${d}.log\">LOG</a></td>" >> ${o}
     fi
-    echo "${space}    <td>${c}</td>"
-    echo "${space}</tr>"
+    echo "${space}    <td>${c}</td>" >> ${o}
+    echo "${space}</tr>" >> ${o}
 }
 #
 # Get options.
@@ -105,36 +106,35 @@ if [[ ! -d ${cacheDir} ]]; then
     chmod o+rx ${cacheDir}
 fi
 #
+# Start the HTML table.
+#
+[[ -f ${cacheDir}/index.html ]] && /bin/rm -f ${cacheDir}/index.html
+timestamp=$(date '+%Y-%m-%d %H:%M:%S %Z')
+cutLine=$(grep --line-number "INSERT CONTENT HERE" ${DESIBACKUP}/etc/backupStatus.html | cut -d: -f1)
+head -$((cutLine - 1)) ${DESIBACKUP}/etc/backupStatus.html | \
+    sed "s%<caption>Last Update: DATE</caption>%<caption>Last Update: ${timestamp}</caption>" > ${cacheDir}/index.html
+#
 # Check all sections in desi.json.
 #
 sections=$(grep -E '^    "[^"]+":\{' ${DESIBACKUP}/etc/desi.json | \
            sed -r 's/^    "([^"]+)":\{/\1/' | \
            grep -v config)
-# cmx: not configured for backup
-# cosmosim: not configured for backup
-# datachallenge:  AUTOFILL
-# engineering: not configured for backup
-# external: empty, not configured for backup
-# metadata: not configured for backup
-# mocks: AUTOFILL
-# protodesi: AUTOFILL (should always be done!)
-# release: empty, not configured for backup
-# science: mostly empty, not configured for backup
-# software: deliberately excluded from backup.
-# spectro: AUTOFILL
-# survey: not configured for backup
-# target: AUTOFILL
-# users: deliberately excluded from backup.
-# www: not configured for backup
+comments=$(cat <<COMMENTS
+datachallenge:<code>quicklook</code> is missing.
+mocks:<code>lya_forest</code> is missing.
+spectro:Only partially configured for backup.
+target:Only <code>cmx_files</code> is configured for backup.
+COMMENTS
+)
 for d in ${sections}; do
     if [[ "${d}" == "external" ]]; then
-        row ${d} COMPLETE False 'Deprecated, empty directory.'
+        row ${d} COMPLETE False 'Deprecated, empty directory.' ${cacheDir}/index.html
     elif [[ "${d}" == "release" ]]; then
-        row ${d} 'NO DATA' False 'Empty directory, no results yet!'
+        row ${d} 'NO DATA' False 'Empty directory, no results yet!' ${cacheDir}/index.html
     elif [[ "${d}" == "software" ]]; then
-        row ${d} 'NO BACKUP' False 'Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.'
+        row ${d} 'NO BACKUP' False 'Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.' ${cacheDir}/index.html
     elif [[ "${d}" == "users" ]]; then
-        row ${d} 'NO BACKUP' False 'The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.'
+        row ${d} 'NO BACKUP' False 'The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.' ${cacheDir}/index.html
     else
         [[ -f ${cacheDir}/missing_files_${d}.log ]] && /bin/rm -f ${cacheDir}/missing_files_${d}.log
         [[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} -D -H -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
@@ -142,21 +142,24 @@ for d in ${sections}; do
         hpss_files=$(<${cacheDir}/hpss_files_${d}.txt)
         missing_files=$(<${cacheDir}/missing_files_${d}.json)
         missing_log=$(<${cacheDir}/missing_files_${d}.log)
+        comment=$(grep "${d}:" <<<"${comments}" | cut -d: -f2)
         if [[ -z "${hpss_files}" && "${missing_files}" == "{}" ]]; then
-            row ${d} 'NO CONFIGURATION' True 'Not configured for backup.'
-        elif [[ -n "${hpss_files}" && "${missing_files}" == "{}" ]]; then
-            row ${d} COMPLETE True 'No missing files found.'
+            [[ -z "${comment}" ]] && comment='Not configured for backup.'
+            row ${d} 'NO CONFIGURATION' True "${comment}" ${cacheDir}/index.html
+        elif [[ -n "${hpss_files}" && -z "${missing_log}" && "${missing_files}" == "{}" ]]; then
+            [[ -z "${comment}" ]] && comment='No missing files found.'
+            row ${d} COMPLETE True "${comment}" ${cacheDir}/index.html
         else
-            row ${d} 'IN PROGRESS' True 'In progress.'
+            [[ -z "${comment}" ]] && comment='In progress.'
+            row ${d} 'IN PROGRESS' True "${comment}" ${cacheDir}/index.html
         fi
     fi
 done
 #
+# Finish the HTML table.
+#
+tail -n +$((cutLine - 1)) ${DESIBACKUP}/etc/backupStatus.html >> ${cacheDir}/index.html
+#
 # Make sure the files are readable.
 #
 chmod o+r ${cacheDir}/*
-#
-#
-#
-timestamp=$(date '+%Y-%m-%d %H:%M:%S %Z')
-sed "s%<caption>Last Update: DATE</caption>%<caption>Last Update: ${timestamp}</caption>" ${DESIBACKUP}/etc/backupStatus.html > ${cacheDir}/index.html

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -123,8 +123,8 @@ target:Only <code>cmx_files</code> is configured for backup.
 COMMENTS
 )
 for d in ${sections}; do
-    if [[ "${d}" == "external" ]]; then
-        row ${d} COMPLETE False 'Deprecated, empty directory.' ${o}
+    if [[ "${d}" == "metadata" ]]; then
+        row ${d} 'NO BACKUP' False 'Directory tree scans provided by NERSC. It is more useful to have these backed up off-site.' ${o}
     elif [[ "${d}" == "release" ]]; then
         row ${d} 'NO DATA' False 'Empty directory, no results yet!' ${o}
     elif [[ "${d}" == "software" ]]; then

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -114,7 +114,7 @@ fi
 timestamp=$(date '+%Y-%m-%d %H:%M:%S %Z')
 cutLine=$(grep --line-number "INSERT CONTENT HERE" ${DESIBACKUP}/etc/backupStatus.html | cut -d: -f1)
 head -$((cutLine - 1)) ${DESIBACKUP}/etc/backupStatus.html | \
-    sed "s%<caption>Last Update: DATE</caption>%<caption>Last Update: ${timestamp}</caption>" > ${cacheDir}/index.html
+    sed "s%<caption>Last Update: DATE</caption>%<caption>Last Update: ${timestamp}</caption>%" > ${cacheDir}/index.html
 #
 # Check all sections in desi.json.
 #

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Licensed under a 3-clause BSD style license - see LICENSE.rst.
+#
+# Help message.
+#
+function usage() {
+    local execName=$(basename $0)
+    (
+    # echo "${execName} [-c DIR] [-h] [-P] [-t] [-v] [-V] DIR"
+    echo "${execName} [-c DIR] [-h] [-v] [-V]"
+    echo ""
+    echo "Report status of DESI backups on HPSS."
+    echo ""
+    echo "-c DIR = Set the location of the cache directory (default ${HOME}/cache)."
+    echo "    -h = Print this message and exit."
+    # echo "    -P = Do NOT issue hsi/htar commands to actually perform backups."
+    # echo "    -t = Test mode. Used to verify backup configuration."
+    echo "    -v = Verbose mode. Print lots of extra information. LOTS."
+    echo "    -V = Version.  Print a version string and exit."
+    # echo ""
+    # echo "   DIR = Top-level directory to examine for backups."
+    ) >&2
+}
+#
+# Version string.
+#
+function version() {
+    local execName=$(basename $0)
+    (
+    cd ${DESIBACKUP}
+    local tags=$(git describe --tags --dirty --always | cut -d- -f1)
+    local revs=$(git rev-list --count HEAD)
+    echo "${execName} version: ${tags}.dev${revs}"
+    echo "HPSSPy version:" $(missing_from_hpss --version)
+    ) >&2
+}
+#
+# Get options.
+#
+cacheDir=${HOME}/cache
+# testMode=''
+# process='--process'
+verbose=''
+# while getopts c:hPtvV argname; do
+while getopts c:hvV argname; do
+    case ${argname} in
+        c) cacheDir=${OPTARG} ;;
+        h) usage; exit 0 ;;
+        # P) process='' ;;
+        # t) testMode='--test' ;;
+        v) verbose='--verbose' ;;
+        V) version; exit 0 ;;
+        *) usage; exit 1 ;;
+    esac
+done
+shift $((OPTIND-1))
+#
+# Make sure cache directory exists.
+#
+if [[ ! -d ${cacheDir} ]]; then
+    echo "Creating directory ${cacheDir} to hold backup cache files." >&2
+    [[ -n "${verbose}" ]] && echo mkdir -p ${cacheDir}
+    mkdir -p ${cacheDir}
+fi
+#
+# Check all sections in desi.json.
+#
+sections=$(grep -E '^    "[^"]+":\{' ${DESIBACKUP}/etc/desi.json | \
+           sed -r 's/^    "([^"]+)":\{/\1/' | \
+           grep -v config)
+space='                            '
+for d in ${sections}; do
+    if [[ "${d}" == "external" ]]; then
+        echo "${space}<tr><td>${d}/</td><td class=\"table-success\"><strong>COMPLETE</strong></td><td>Deprecated, empty directory.</td></tr>"
+    elif [[ "${d}" == "release" ]]; then
+        echo "${space}<tr><td>${d}/</td><td class=\"table-info\"><strong>NO DATA</strong></td><td>Empty directory, no results yet!</td></tr>"
+    elif [[ "${d}" == "software" ]]; then
+        echo "${space}<tr><td>${d}/</td><td class=\"table-info\"><strong>NO BACKUP</strong></td><td>Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.</td></tr>"
+    elif [[ "${d}" == "users" ]]; then
+        echo "${space}<tr><td>${d}/</td><td class=\"table-info\"><strong>NO BACKUP</strong></td><td>The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.</td></tr>"
+    else
+        [[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} -D -H -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
+        log=$(missing_from_hpss ${verbose} -D -H -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d})
+        hpss_files=$(<${HOME}/cache/hpss_files_${d}.txt)
+        missing_files=$(<${HOME}/cache/hpss_files_${d}.txt)
+        if [[ -z "${hpss_files}" && "${missing_files}" == "{}" ]]; then
+            echo "${space}<tr><td>${d}/</td><td class=\"table-danger\"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>"
+        fi
+    fi
+done
+# cmx: not configured for backup
+# cosmosim: not configured for backup
+# datachallenge:  AUTOFILL
+# engineering: not configured for backup
+# external: empty, not configured for backup
+# metadata: not configured for backup
+# mocks: AUTOFILL
+# protodesi: AUTOFILL (should always be done!)
+# release: empty, not configured for backup
+# science: mostly empty, not configured for backup
+# software: deliberately excluded from backup.
+# spectro: AUTOFILL
+# survey: not configured for backup
+# target: AUTOFILL
+# users: deliberately excluded from backup.
+# www: not configured for backup

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -155,3 +155,8 @@ done
 # Make sure the files are readable.
 #
 chmod o+r ${cacheDir}/*
+#
+#
+#
+timestamp=$(date '+%Y-%m-%d %H:%M:%S %Z')
+sed "s%<caption>Last Update: DATE</caption>%<caption>Last Update: ${timestamp}</caption>" ${DESIBACKUP}/etc/backupStatus.html > ${cacheDir}/index.html

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -139,7 +139,7 @@ for d in ${sections}; do
         fi
         hpss_files=$(<${cacheDir}/hpss_files_${d}.txt)
         missing_files=$(<${cacheDir}/missing_files_${d}.json)
-        missing_log=$(<${cacheDir}/missing_files_${d}.log)
+        missing_log=$(grep -v INFO ${cacheDir}/missing_files_${d}.log)
         comment=$(grep "${d}:" <<<"${comments}" | cut -d: -f2)
         if [[ -z "${hpss_files}" && "${missing_files}" == "{}" ]]; then
             [[ -z "${comment}" ]] && comment='Not configured for backup.'

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -132,8 +132,8 @@ for d in ${sections}; do
     elif [[ "${d}" == "users" ]]; then
         row ${d} 'NO BACKUP' False 'The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.' ${o}
     else
-        [[ -f ${cacheDir}/missing_files_${d}.log ]] && rm -f ${cacheDir}/missing_files_${d}.log
-        if [[ -n "${fastMode}" ]]; then
+        if [[ -z "${fastMode}" ]]; then
+            [[ -f ${cacheDir}/missing_files_${d}.log ]] && rm -f ${cacheDir}/missing_files_${d}.log
             [[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} -D -H -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d} >&2
             missing_from_hpss ${verbose} -D -H -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d} > ${cacheDir}/missing_files_${d}.log 2>&1
         fi

--- a/bin/desiBackup.sh
+++ b/bin/desiBackup.sh
@@ -5,12 +5,13 @@
 function usage() {
     local execName=$(basename $0)
     (
-    echo "${execName} [-c DIR] [-h] [-t] [-v] [-V] DIR"
+    echo "${execName} [-c DIR] [-h] [-p] [-t] [-v] [-V] DIR"
     echo ""
     echo "Backup DESI files to HPSS."
     echo ""
     echo "-c DIR = Set the location of the cache directory (default ${HOME}/cache)."
     echo "    -h = Print this message and exit."
+    echo "    -p = Process. Issue hsi/htar commands to actually perform backups."
     echo "    -t = Test mode. Used to verify backup configuration."
     echo "    -v = Verbose mode. Print lots of extra information. LOTS."
     echo "    -V = Version.  Print a version string and exit."
@@ -35,12 +36,14 @@ function version() {
 # Get options.
 #
 cacheDir=${HOME}/cache
-testMode='--process'
+testMode=''
+process=''
 verbose=''
-while getopts c:htvV argname; do
+while getopts c:hptvV argname; do
     case ${argname} in
         c) cacheDir=${OPTARG} ;;
         h) usage; exit 0 ;;
+        p) process='--process' ;;
         t) testMode='--test' ;;
         v) verbose='--verbose' ;;
         V) version; exit 0 ;;
@@ -77,6 +80,6 @@ fi
 # Run on directory.
 #
 for d in ${sections}; do
-    [[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} ${testMode} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
-    missing_from_hpss ${verbose} ${testMode} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
+    [[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} ${testMode} ${process} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
+    missing_from_hpss ${verbose} ${testMode} ${process} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
 done

--- a/bin/desiBackup.sh
+++ b/bin/desiBackup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Licensed under a 3-clause BSD style license - see LICENSE.rst.
 #
 # Help message.
 #

--- a/bin/desiBackup.sh
+++ b/bin/desiBackup.sh
@@ -76,7 +76,7 @@ fi
 #
 # Run on directory.
 #
-for d in sections; do
+for d in ${sections}; do
     [[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} ${testMode} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
     missing_from_hpss ${verbose} ${testMode} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
 done

--- a/bin/desiBackup.sh
+++ b/bin/desiBackup.sh
@@ -5,13 +5,13 @@
 function usage() {
     local execName=$(basename $0)
     (
-    echo "${execName} [-c DIR] [-h] [-p] [-t] [-v] [-V] DIR"
+    echo "${execName} [-c DIR] [-h] [-P] [-t] [-v] [-V] DIR"
     echo ""
     echo "Backup DESI files to HPSS."
     echo ""
     echo "-c DIR = Set the location of the cache directory (default ${HOME}/cache)."
     echo "    -h = Print this message and exit."
-    echo "    -p = Process. Issue hsi/htar commands to actually perform backups."
+    echo "    -P = Do NOT issue hsi/htar commands to actually perform backups."
     echo "    -t = Test mode. Used to verify backup configuration."
     echo "    -v = Verbose mode. Print lots of extra information. LOTS."
     echo "    -V = Version.  Print a version string and exit."
@@ -37,13 +37,13 @@ function version() {
 #
 cacheDir=${HOME}/cache
 testMode=''
-process=''
+process='--process'
 verbose=''
-while getopts c:hptvV argname; do
+while getopts c:hPtvV argname; do
     case ${argname} in
         c) cacheDir=${OPTARG} ;;
         h) usage; exit 0 ;;
-        p) process='--process' ;;
+        P) process='' ;;
         t) testMode='--test' ;;
         v) verbose='--verbose' ;;
         V) version; exit 0 ;;

--- a/bin/desiBackup.sh
+++ b/bin/desiBackup.sh
@@ -64,7 +64,19 @@ if [[ ! -d ${cacheDir} ]]; then
     mkdir -p ${cacheDir}
 fi
 #
-# Pass options to
+# All directories?
 #
-[[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} ${testMode} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json $1
-missing_from_hpss ${verbose} ${testMode} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json $1
+if [[ "$1" == "ALL" ]]; then
+    sections=$(grep -E '^    "[^"]+":\{' ${DESIBACKUP}/etc/desi.json | \
+               sed -r 's/^    "([^"]+)":\{/\1/' | \
+               grep -v config)
+else
+    sections=$1
+fi
+#
+# Run on directory.
+#
+for d in sections; do
+    [[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} ${testMode} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
+    missing_from_hpss ${verbose} ${testMode} -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d}
+done

--- a/etc/backupStatus.html
+++ b/etc/backupStatus.html
@@ -8,7 +8,6 @@
         href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" title="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
         integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
         crossorigin="anonymous" />
-    <!-- <link rel="stylesheet" type="text/css" media="screen" href="dts_status.css" title="dts_status.css" /> -->
     <script type="text/javascript"
         src="https://code.jquery.com/jquery-3.3.1.min.js"
         integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
@@ -31,11 +30,12 @@
                     <h2>Backup Status Table</h2>
                     <p>Documentation</p>
                     <table class="table table-bordered">
-                        <caption>Backup Status Table</caption>
+                        <caption>Last Update: DATE</caption>
                         <thead>
                             <tr><th>Directory</th><th>Status</th><th>Files on Disk</th><th>Files on HPSS</th><th>Potential Backups</th><th>Log</th><th>Comments</th></tr>
                         </thead>
                         <tbody>
+                            <!-- INSERT CONTENT HERE -->
                             <tr>
                                 <td>cmx/</td>
                                 <td class="table-danger"><strong>NO CONFIGURATION</strong></td>

--- a/etc/backupStatus.html
+++ b/etc/backupStatus.html
@@ -12,7 +12,7 @@
         src="https://code.jquery.com/jquery-3.3.1.min.js"
         integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
         crossorigin="anonymous"></script>
-    <!-- <script type="text/javascript" src="desiBackup.js"></script> -->
+    <!-- <script type="text/javascript" src="backupStatus.js"></script> -->
     <style type="text/css">
     html { overflow-y: scroll; }
     </style>
@@ -21,14 +21,41 @@
     <div class="container-fluid">
         <div class="row">
             <div class="col-12">
-                <h1>DESI Backup Status</h1>
+                <h1 id="Top">DESI Backup Status</h1>
             </div><!-- end class="col-12" -->
         </div><!-- end class="row" -->
         <div id="content">
             <div class="row">
                 <div class="col-12">
-                    <h2>Backup Status Table</h2>
-                    <p>Documentation</p>
+                    <h2 id="status">Backup Status Table</h2>
+                    <p>This page describes the state of backups of DESI data to
+                        <a href="https://www.nersc.gov/systems/hpss-data-archive/">HPSS</a>.
+                        Each row in the table below corresponds to a top-level directory in
+                        <code>/global/project/projectdirs/desi</code>.
+                        On HPSS, the top-level DESI directory is <code>/nersc/projects/desi</code>.
+                        Backup files and directories below are relative to this directory.
+                        See <a href="https://desi.lbl.gov/trac/wiki/Pipeline/Backups">DESI Trac Wiki</a>
+                        for more details.
+                    </p>
+                    <p>The "Status" column below is set according to these definitions:</p>
+                    <dl class="row">
+                        <dt class="col-sm-2 table-danger">NO CONFIGURATION</dt>
+                        <dd class="col-sm-10">The Data Management team needs to
+                            examine the contents of this directory and determine
+                            the best configuration for backups.  In some cases,
+                            the backups will be automated; in other cases, the
+                            backups will be one-off, "by-hand" backups.</dd>
+                        <dt class="col-sm-2 table-warning">IN PROGRESS</dt>
+                        <dd class="col-sm-10">The directory is at least partially
+                            backed up, through automation or otherwise.
+                            Some subdirectories might not be configured for backup.</dd>
+                        <dt class="col-sm-2 table-success">COMPLETE</dt>
+                        <dd class="col-sm-10">All files on disk are backed up.  In some cases this indicates a completely static data set.</dd>
+                        <dt class="col-sm-2 table-info">NO BACKUP/DATA</dt>
+                        <dd class="col-sm-10">A directory is deliberately not
+                            backed up for a specific reason, or it is an
+                            empty placeholder that may contain data in the future.</dd>
+                    </dl>
                     <table class="table table-bordered">
                         <caption>Last Update: DATE</caption>
                         <thead>
@@ -36,150 +63,6 @@
                         </thead>
                         <tbody>
                             <!-- INSERT CONTENT HERE -->
-                            <tr>
-                                <td>cmx/</td>
-                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_cmx.csv" title="disk_files_cmx.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_cmx.txt" title="hpss_files_cmx.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_cmx.json" title="missing_files_cmx.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_cmx.log" title="missing_files_cmx.log">LOG</a></td>
-                                <td>Not configured for backup.</td>
-                            </tr>
-                            <tr>
-                                <td>cosmosim/</td>
-                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_cosmosim.csv" title="disk_files_cosmosim.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_cosmosim.txt" title="hpss_files_cosmosim.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_cosmosim.json" title="missing_files_cosmosim.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_cosmosim.log" title="missing_files_cosmosim.log">LOG</a></td>
-                                <td>Not configured for backup.</td>
-                            </tr>
-                            <tr>
-                                <td>datachallenge/</td>
-                                <td class="table-warning"><strong>IN PROGRESS</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_datachallenge.csv" title="disk_files_datachallenge.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_datachallenge.txt" title="hpss_files_datachallenge.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_datachallenge.json" title="missing_files_datachallenge.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_datachallenge.log" title="missing_files_datachallenge.log">LOG</a></td>
-                                <td><code>quicklook</code> is missing.</td>
-                            </tr>
-                            <tr>
-                                <td>engineering/</td>
-                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_engineering.csv" title="disk_files_engineering.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_engineering.txt" title="hpss_files_engineering.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_engineering.json" title="missing_files_engineering.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_engineering.log" title="missing_files_engineering.log">LOG</a></td>
-                                <td>Not configured for backup.</td>
-                            </tr>
-                            <tr>
-                                <td>external/</td>
-                                <td class="table-success"><strong>COMPLETE</strong></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">LOG</a></td>
-                                <td>Deprecated, empty directory.</td>
-                            </tr>
-                            <tr>
-                                <td>metadata/</td>
-                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_metadata.csv" title="disk_files_metadata.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_metadata.txt" title="hpss_files_metadata.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_metadata.json" title="missing_files_metadata.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_metadata.log" title="missing_files_metadata.log">LOG</a></td>
-                                <td>Not configured for backup.</td>
-                            </tr>
-                            <tr>
-                                <td>mocks/</td>
-                                <td class="table-warning"><strong>IN PROGRESS</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_mocks.csv" title="disk_files_mocks.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_mocks.txt" title="hpss_files_mocks.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_mocks.json" title="missing_files_mocks.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_mocks.log" title="missing_files_mocks.log">LOG</a></td>
-                                <td><code>lya_forest</code> is missing.</td>
-                            </tr>
-                            <tr>
-                                <td>protodesi/</td>
-                                <td class="table-success"><strong>COMPLETE</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_protodesi.csv" title="disk_files_protodesi.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_protodesi.txt" title="hpss_files_protodesi.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_protodesi.json" title="missing_files_protodesi.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_protodesi.log" title="missing_files_protodesi.log">LOG</a></td>
-                                <td>No missing files found.</td>
-                            </tr>
-                            <tr>
-                                <td>release/</td>
-                                <td class="table-info"><strong>NO DATA</strong></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">LOG</a></td>
-                                <td>Empty directory, no results yet!</td>
-                            </tr>
-                            <tr>
-                                <td>science/</td>
-                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_science.csv" title="disk_files_science.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_science.txt" title="hpss_files_science.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_science.json" title="missing_files_science.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_science.log" title="missing_files_science.log">LOG</a></td>
-                                <td>Not configured for backup.</td>
-                            </tr>
-                            <tr>
-                                <td>software/</td>
-                                <td class="table-info"><strong>NO BACKUP</strong></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">LOG</a></td>
-                                <td>Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.</td>
-                            </tr>
-                            <tr>
-                                <td>spectro/</td>
-                                <td class="table-warning"><strong>IN PROGRESS</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_spectro.csv" title="disk_files_spectro.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_spectro.txt" title="hpss_files_spectro.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_spectro.json" title="missing_files_spectro.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_spectro.log" title="missing_files_spectro.log">LOG</a></td>
-                                <td>Only partially configured for backup.</td>
-                            </tr>
-                            <tr>
-                                <td>survey/</td>
-                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_survey.csv" title="disk_files_survey.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_survey.txt" title="hpss_files_survey.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_survey.json" title="missing_files_survey.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_survey.log" title="missing_files_survey.log">LOG</a></td>
-                                <td>Not configured for backup.</td>
-                            </tr>
-                            <tr>
-                                <td>target/</td>
-                                <td class="table-warning"><strong>IN PROGRESS</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_target.csv" title="disk_files_target.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_target.txt" title="hpss_files_target.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_target.json" title="missing_files_target.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_target.log" title="missing_files_target.log">LOG</a></td>
-                                <td>Only <code>cmx_files</code> is configured for backup.</td>
-                            </tr>
-                            <tr>
-                                <td>users/</td>
-                                <td class="table-info"><strong>NO BACKUP</strong></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">LOG</a></td>
-                                <td>The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.</td>
-                            </tr>
-                            <tr>
-                                <td>www/</td>
-                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_www.csv" title="disk_files_www.csv">CSV</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_www.txt" title="hpss_files_www.txt">TXT</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_www.json" title="missing_files_www.json">JSON</a></td>
-                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_www.log" title="missing_files_www.log">LOG</a></td>
-                                <td>Not configured for backup.</td>
-                            </tr>
                         </tbody>
                     </table>
                 </div><!-- end class="col-12" -->
@@ -187,7 +70,7 @@
         </div><!-- end id="content" -->
         <div class="row">
             <div class="col-12">
-                <h2>Other Backups</h2>
+                <h2 id="status">Other Backups</h2>
                 <p>These backups <em>no longer</em> correspond to any top-level data directory at NERSC.</p>
                 <ul>
                     <li>bigboss/

--- a/etc/backupStatus.html
+++ b/etc/backupStatus.html
@@ -71,7 +71,8 @@
         <div class="row">
             <div class="col-12">
                 <h2 id="status">Other Backups</h2>
-                <p>These backups <em>no longer</em> correspond to any top-level data directory at NERSC.</p>
+                <p>These backups <em>no longer</em> correspond to any top-level data directory at NERSC.
+                    <em>Exception</em>: the 'external' directory still exists but is empty.</p>
                 <ul>
                     <li>bigboss/
                         <ul>
@@ -122,6 +123,26 @@
                         </ul>
                     </li>
                     <li><code>cosmos_nvo.tar</code></li>
+                    <li>external/
+                        <ul>
+                            <li>spectest/
+                                <ul>
+                                    <li>boss/
+                                        <ul>
+                                            <li>3647/
+                                                <ul>
+                                                    <li><code>spectest_boss_3647_3647.tar</code></li>
+                                                    <li><code>spectest_boss_3647_files.tar</code></li>
+                                                    <li><code>spectest_boss_3647_jguy.tar</code></li>
+                                                    <li><code>spectest_boss_3647_preproc.tar</code></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
                     <li>imaging/
                         <ul>
                             <li>cats/

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -5,10 +5,16 @@
         "physical_disks":["desi"]
     },
     "cmx":{
-        "exclude":[]
+        "exclude":["README"],
+        "ci":{
+        }
     },
     "cosmosim":{
-        "exclude":[]
+        "exclude":[],
+        "ELG_HOD":{
+        },
+        "proto_sim":{
+        }
     },
     "datachallenge":{
         "exclude":[],
@@ -62,6 +68,8 @@
         "mockobs-18.6":{
             "mockobs-18.6/.*$":"mockobs-18.6.tar"
         },
+        "quicklook":{
+        },
         "quicksurvey2016":{
             "quicksurvey2016/[^/]+$":"quicksurvey2016/quicksurvey2016_files.tar",
             "quicksurvey2016/(input|output|plots|surveysim)/.*$":"quicksurvey2016/quicksurvey2016_\\1.tar"
@@ -93,6 +101,8 @@
             "reference_runs/([0-9.a]+|cptest)/(fiberassign|survey|targets)/.*$":"reference_runs/\\1/reference_runs_\\1_\\2.tar",
             "reference_runs/([0-9.a]+|cptest)/spectro/(redux|sim)/.*$":"reference_runs/\\1/spectro/reference_runs_\\1_spectro_\\2.tar"
         },
+        "staging":{
+        },
         "surveysim2017":{
             "surveysim2017/.*$":"surveysim2017.tar"
         },
@@ -111,16 +121,25 @@
         }
     },
     "engineering":{
-        "exclude":[]
+        "exclude":[],
+        "focalplane":{
+        },
+        "gfa":{
+        },
+        "pfa":{
+        },
+        "pfa2positioner":{
+        },
+        "spectrograph":{
+        },
+        "svn_export_focalplane_12302018":{
+        }
     },
     "external":{
-        "exclude":[]
-    },
-    "imaging":{
-        "exclude":[]
+        "exclude":["README"]
     },
     "metadata":{
-        "exclude":[]
+        "exclude":["README.html","scan_README.txt"]
     },
     "mocks":{
         "exclude":[],
@@ -153,7 +172,8 @@
         "lightcone_galform":{
             "lightcone_galform/.*$":"lightcone_galform.tar"
         },
-        "lya_forest":{},
+        "lya_forest":{
+        },
         "mws":{
             "mws/(100pc|gaiaDR1quick|small_galaxia|wd|wd100pc)/.*$":"mws/mws_\\1.tar",
             "mws/galaxia/alpha/v0.0.6/READ_ME":"mws/galaxia/alpha/v0.0.6/READ_ME",
@@ -183,18 +203,41 @@
         "exclude":[]
     },
     "science":{
-        "exclude":[]
+        "exclude":["README"],
+        "bgs":{
+        },
+        "c3":{
+        },
+        "gqc":{
+        },
+        "lya":{
+        },
+        "mws":{
+        }
     },
     "software":{
         "exclude":[]
     },
     "spectro":{
         "exclude":["README.html"],
-        "data":{
+        "StrayLight":{
         },
-        "exposures":{
+        "ZemaxSimulation":{
+        },
+        "calib":{
+        },
+        "ccd_calibration_data":{
+        },
+        "data":{
+            "data/([0-9]+)/.*$":"data/desi_spectro_data_\\1.tar"
+        },
+        "desi_spectro_calib":{
+        },
+        "ql_calib":{
         },
         "quickcat":{
+        },
+        "quicklook":{
         },
         "redux":{
             "redux/sjb/dogwood/.*$":"redux/sjb/dogwood.tar",
@@ -202,20 +245,49 @@
         },
         "sim":{
         },
+        "staging":{
+        },
         "templates":{
+        },
+        "testdata":{
         },
         "teststand":{
         }
     },
     "survey":{
-        "exclude":[]
+        "exclude":[],
+        "planning":{
+        },
+        "sims":{
+        }
     },
     "target":{
         "exclude":["README.html"],
+        "RF_files":{
+        },
+        "analysis":{
+        },
+        "catalogs":{
+        },
         "cmx_files":{
             "cmx_files/.*$":"cmx_files.tar"
         },
-        "secondary":{}
+        "elg_targets_dr3":{
+        },
+        "fiberassign":{
+        },
+        "gaia_dr2":{
+        },
+        "gaia_dr2_match_dr6":{
+        },
+        "qso_targets_dr3":{
+        },
+        "qso_training":{
+        },
+        "secondary":{
+        },
+        "stripe82-dr2":{
+        }
     },
     "users":{
         "exclude":[]

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -172,7 +172,9 @@
         "lya_forest":{
             "lya_forest/london/v4\\.2\\.0/[^/]+$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_files.tar",
             "lya_forest/london/v4\\.2\\.0/([0-9]+)/.*$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_\\1.tar",
-            "lya_forest/london/v4\\.2\\.0/quick-([0-9.]+)/.*$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_quick-\\1.tar"
+            "lya_forest/london/v4\\.2\\.0/quick-([0-9.]+)/.*$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_quick-\\1.tar",
+            "lya_forest/saclay/v4\\.2/.*$":"lya_forest/saclay/lya_forest_saclay_v4.2.tar",
+            "lya_forest/saclay/v4\\.4/v4\\.4\\.([0-9]+)/.*$":"lya_forest/saclay/v4.4/lya_forest_saclay_v4.4_v4.4.\\1.tar"
         },
         "mws":{
             "mws/(100pc|gaiaDR1quick|small_galaxia|wd|wd100pc)/.*$":"mws/mws_\\1.tar",

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -224,10 +224,6 @@
         },
         "ZemaxSimulation":{
         },
-        "calib":{
-        },
-        "ccd_calibration_data":{
-        },
         "data":{
             "data/([0-9]+)/.*$":"data/desi_spectro_data_\\1.tar"
         },

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -135,9 +135,6 @@
         "svn_export_focalplane_12302018":{
         }
     },
-    "external":{
-        "exclude":["README"]
-    },
     "metadata":{
         "exclude":["README.html","scan_README.txt"]
     },

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -170,6 +170,9 @@
             "lightcone_galform/.*$":"lightcone_galform.tar"
         },
         "lya_forest":{
+            "lya_forest/london/v4\\.2\\.0/[^/]+$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_files.tar",
+            "lya_forest/london/v4\\.2\\.0/([0-9]+)/.*$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_\\1.tar",
+            "lya_forest/london/v4\\.2\\.0/quick-([0-9.]+)/.*$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_quick-\\1.tar"
         },
         "mws":{
             "mws/(100pc|gaiaDR1quick|small_galaxia|wd|wd100pc)/.*$":"mws/mws_\\1.tar",

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -4,6 +4,12 @@
         "hpss_root":"/nersc/projects/desi",
         "physical_disks":["desi"]
     },
+    "cmx":{
+        "exclude":[]
+    },
+    "cosmosim":{
+        "exclude":[]
+    },
     "datachallenge":{
         "exclude":[],
         "Argonne2015":{
@@ -104,10 +110,16 @@
             "zdc2/samples/boss-(elg|gal|qso)/.*$":"zdc2/samples/zdc2_samples_boss-\\1.tar"
         }
     },
+    "engineering":{
+        "exclude":[]
+    },
     "external":{
         "exclude":[]
     },
     "imaging":{
+        "exclude":[]
+    },
+    "metadata":{
         "exclude":[]
     },
     "mocks":{
@@ -170,6 +182,12 @@
     "release":{
         "exclude":[]
     },
+    "science":{
+        "exclude":[]
+    },
+    "software":{
+        "exclude":[]
+    },
     "spectro":{
         "exclude":["README.html"],
         "data":{
@@ -198,5 +216,11 @@
             "cmx_files/.*$":"cmx_files.tar"
         },
         "secondary":{}
+    },
+    "users":{
+        "exclude":[]
+    },
+    "www":{
+        "exclude":[]
     }
 }

--- a/etc/desiBackup.html
+++ b/etc/desiBackup.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <link rel="stylesheet" type="text/css"
-        href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+        href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" title="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
         integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
         crossorigin="anonymous" />
-    <!-- <link rel="stylesheet" type="text/css" media="screen" href="dts_status.css" /> -->
+    <!-- <link rel="stylesheet" type="text/css" media="screen" href="dts_status.css" title="dts_status.css" /> -->
     <script type="text/javascript"
         src="https://code.jquery.com/jquery-3.3.1.min.js"
         integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
@@ -19,7 +19,7 @@
     </style>
 </head>
 <body>
-    <div class="container">
+    <div class="container-fluid">
         <div class="row">
             <div class="col-12">
                 <h1>DESI Backup Status</h1>
@@ -33,25 +33,153 @@
                     <table class="table table-bordered">
                         <caption>Backup Status Table</caption>
                         <thead>
-                            <tr><th>Directory</th><th>Status</th><th>Comments</th></tr>
+                            <tr><th>Directory</th><th>Status</th><th>Files on Disk</th><th>Files on HPSS</th><th>Potential Backups</th><th>Log</th><th>Comments</th></tr>
                         </thead>
                         <tbody>
-                            <tr><td>cmx/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
-                            <tr><td>cosmosim/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
-                            <tr><td>datachallenge/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td><code>quicklook</code> is missing.</td></tr>
-                            <tr><td>engineering/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
-                            <tr><td>external/</td><td class="table-success"><strong>COMPLETE</strong></td><td>Deprecated, empty directory.</td></tr>
-                            <tr><td>metadata/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
-                            <tr><td>mocks/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td><code>lya_forest</code> is missing.</td></tr>
-                            <tr><td>protodesi/</td><td class="table-success"><strong>COMPLETE</strong></td><td>No missing files found.</td></tr>
-                            <tr><td>release/</td><td class="table-info"><strong>NO DATA</strong></td><td>Empty directory, no results yet!</td></tr>
-                            <tr><td>science/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
-                            <tr><td>software/</td><td class="table-info"><strong>NO BACKUP</strong></td><td>Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.</td></tr>
-                            <tr><td>spectro/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td>Only partially configured for backup.</td></tr>
-                            <tr><td>survey/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
-                            <tr><td>target/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td>Only <code>cmx_files</code> is configured for backup.</td></tr>
-                            <tr><td>users/</td><td class="table-info"><strong>NO BACKUP</strong></td><td>The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.</td></tr>
-                            <tr><td>www/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
+                            <tr>
+                                <td>cmx/</td>
+                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_cmx.csv" title="disk_files_cmx.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_cmx.txt" title="hpss_files_cmx.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_cmx.json" title="missing_files_cmx.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_cmx.log" title="missing_files_cmx.log">LOG</a></td>
+                                <td>Not configured for backup.</td>
+                            </tr>
+                            <tr>
+                                <td>cosmosim/</td>
+                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_cosmosim.csv" title="disk_files_cosmosim.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_cosmosim.txt" title="hpss_files_cosmosim.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_cosmosim.json" title="missing_files_cosmosim.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_cosmosim.log" title="missing_files_cosmosim.log">LOG</a></td>
+                                <td>Not configured for backup.</td>
+                            </tr>
+                            <tr>
+                                <td>datachallenge/</td>
+                                <td class="table-warning"><strong>IN PROGRESS</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_datachallenge.csv" title="disk_files_datachallenge.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_datachallenge.txt" title="hpss_files_datachallenge.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_datachallenge.json" title="missing_files_datachallenge.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_datachallenge.log" title="missing_files_datachallenge.log">LOG</a></td>
+                                <td><code>quicklook</code> is missing.</td>
+                            </tr>
+                            <tr>
+                                <td>engineering/</td>
+                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_engineering.csv" title="disk_files_engineering.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_engineering.txt" title="hpss_files_engineering.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_engineering.json" title="missing_files_engineering.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_engineering.log" title="missing_files_engineering.log">LOG</a></td>
+                                <td>Not configured for backup.</td>
+                            </tr>
+                            <tr>
+                                <td>external/</td>
+                                <td class="table-success"><strong>COMPLETE</strong></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">LOG</a></td>
+                                <td>Deprecated, empty directory.</td>
+                            </tr>
+                            <tr>
+                                <td>metadata/</td>
+                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_metadata.csv" title="disk_files_metadata.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_metadata.txt" title="hpss_files_metadata.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_metadata.json" title="missing_files_metadata.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_metadata.log" title="missing_files_metadata.log">LOG</a></td>
+                                <td>Not configured for backup.</td>
+                            </tr>
+                            <tr>
+                                <td>mocks/</td>
+                                <td class="table-warning"><strong>IN PROGRESS</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_mocks.csv" title="disk_files_mocks.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_mocks.txt" title="hpss_files_mocks.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_mocks.json" title="missing_files_mocks.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_mocks.log" title="missing_files_mocks.log">LOG</a></td>
+                                <td><code>lya_forest</code> is missing.</td>
+                            </tr>
+                            <tr>
+                                <td>protodesi/</td>
+                                <td class="table-success"><strong>COMPLETE</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_protodesi.csv" title="disk_files_protodesi.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_protodesi.txt" title="hpss_files_protodesi.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_protodesi.json" title="missing_files_protodesi.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_protodesi.log" title="missing_files_protodesi.log">LOG</a></td>
+                                <td>No missing files found.</td>
+                            </tr>
+                            <tr>
+                                <td>release/</td>
+                                <td class="table-info"><strong>NO DATA</strong></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">LOG</a></td>
+                                <td>Empty directory, no results yet!</td>
+                            </tr>
+                            <tr>
+                                <td>science/</td>
+                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_science.csv" title="disk_files_science.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_science.txt" title="hpss_files_science.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_science.json" title="missing_files_science.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_science.log" title="missing_files_science.log">LOG</a></td>
+                                <td>Not configured for backup.</td>
+                            </tr>
+                            <tr>
+                                <td>software/</td>
+                                <td class="table-info"><strong>NO BACKUP</strong></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">LOG</a></td>
+                                <td>Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.</td>
+                            </tr>
+                            <tr>
+                                <td>spectro/</td>
+                                <td class="table-warning"><strong>IN PROGRESS</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_spectro.csv" title="disk_files_spectro.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_spectro.txt" title="hpss_files_spectro.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_spectro.json" title="missing_files_spectro.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_spectro.log" title="missing_files_spectro.log">LOG</a></td>
+                                <td>Only partially configured for backup.</td>
+                            </tr>
+                            <tr>
+                                <td>survey/</td>
+                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_survey.csv" title="disk_files_survey.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_survey.txt" title="hpss_files_survey.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_survey.json" title="missing_files_survey.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_survey.log" title="missing_files_survey.log">LOG</a></td>
+                                <td>Not configured for backup.</td>
+                            </tr>
+                            <tr>
+                                <td>target/</td>
+                                <td class="table-warning"><strong>IN PROGRESS</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_target.csv" title="disk_files_target.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_target.txt" title="hpss_files_target.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_target.json" title="missing_files_target.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_target.log" title="missing_files_target.log">LOG</a></td>
+                                <td>Only <code>cmx_files</code> is configured for backup.</td>
+                            </tr>
+                            <tr>
+                                <td>users/</td>
+                                <td class="table-info"><strong>NO BACKUP</strong></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-light" role="button" href="#" title="Status not run.">LOG</a></td>
+                                <td>The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.</td>
+                            </tr>
+                            <tr>
+                                <td>www/</td>
+                                <td class="table-danger"><strong>NO CONFIGURATION</strong></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="disk_files_www.csv" title="disk_files_www.csv">CSV</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="hpss_files_www.txt" title="hpss_files_www.txt">TXT</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_www.json" title="missing_files_www.json">JSON</a></td>
+                                <td><a class="btn btn-sm btn-outline-primary" role="button" href="missing_files_www.log" title="missing_files_www.log">LOG</a></td>
+                                <td>Not configured for backup.</td>
+                            </tr>
                         </tbody>
                     </table>
                 </div><!-- end class="col-12" -->

--- a/etc/desiBackup.html
+++ b/etc/desiBackup.html
@@ -47,7 +47,7 @@
                             <tr><td>release/</td><td class="table-info"><strong>NO DATA</strong></td><td>Empty directory, no results yet!</td></tr>
                             <tr><td>science/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
                             <tr><td>software/</td><td class="table-info"><strong>NO BACKUP</strong></td><td>Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.</td></tr>
-                            <tr><td>spectro/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td>Only <code>cmx_files</code> is configured for backup.</td></tr>
+                            <tr><td>spectro/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td>Only partially configured for backup.</td></tr>
                             <tr><td>survey/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
                             <tr><td>target/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td>Only <code>cmx_files</code> is configured for backup.</td></tr>
                             <tr><td>users/</td><td class="table-info"><strong>NO BACKUP</strong></td><td>The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.</td></tr>

--- a/etc/desiBackup.html
+++ b/etc/desiBackup.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>DESI Backup Status</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <link rel="stylesheet" type="text/css"
+        href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+        integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
+        crossorigin="anonymous" />
+    <!-- <link rel="stylesheet" type="text/css" media="screen" href="dts_status.css" /> -->
+    <script type="text/javascript"
+        src="https://code.jquery.com/jquery-3.3.1.min.js"
+        integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+        crossorigin="anonymous"></script>
+    <!-- <script type="text/javascript" src="desiBackup.js"></script> -->
+    <style type="text/css">
+    html { overflow-y: scroll; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h1>DESI Backup Status</h1>
+            </div><!-- end class="col-12" -->
+        </div><!-- end class="row" -->
+        <div id="content">
+            <div class="row">
+                <div class="col-12">
+                    <h2>Backup Status Table</h2>
+                    <p>Documentation</p>
+                    <table class="table table-bordered">
+                        <caption>Backup Status Table</caption>
+                        <thead>
+                            <tr><th>Directory</th><th>Status</th><th>Comments</th></tr>
+                        </thead>
+                        <tbody>
+                            <tr><td>cmx/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
+                            <tr><td>cosmosim/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
+                            <tr><td>datachallenge/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td><code>quicklook</code> is missing.</td></tr>
+                            <tr><td>engineering/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
+                            <tr><td>external/</td><td class="table-success"><strong>COMPLETE</strong></td><td>Deprecated, empty directory.</td></tr>
+                            <tr><td>metadata/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
+                            <tr><td>mocks/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td><code>lya_forest</code> is missing.</td></tr>
+                            <tr><td>protodesi/</td><td class="table-success"><strong>COMPLETE</strong></td><td>No missing files found.</td></tr>
+                            <tr><td>release/</td><td class="table-info"><strong>NO DATA</strong></td><td>Empty directory, no results yet!</td></tr>
+                            <tr><td>science/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
+                            <tr><td>software/</td><td class="table-info"><strong>NO BACKUP</strong></td><td>Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.</td></tr>
+                            <tr><td>spectro/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td>Only <code>cmx_files</code> is configured for backup.</td></tr>
+                            <tr><td>survey/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
+                            <tr><td>target/</td><td class="table-warning"><strong>IN PROGRESS</strong></td><td>Only <code>cmx_files</code> is configured for backup.</td></tr>
+                            <tr><td>users/</td><td class="table-info"><strong>NO BACKUP</strong></td><td>The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.</td></tr>
+                            <tr><td>www/</td><td class="table-danger"><strong>NO CONFIGURATION</strong></td><td>Not configured for backup.</td></tr>
+                        </tbody>
+                    </table>
+                </div><!-- end class="col-12" -->
+            </div><!-- end class="row" -->
+        </div><!-- end id="content" -->
+        <div class="row">
+            <div class="col-12">
+                <h2>Other Backups</h2>
+                <p>These backups <em>no longer</em> correspond to any top-level data directory at NERSC.</p>
+                <ul>
+                    <li>bigboss/
+                        <ul>
+                            <li><code>bbspecsim.tar</code></li>
+                            <li>data/
+                                <ul>
+                                    <li>ctio/
+                                        <ul>
+                                            <li>Stripe82/
+                                                <ul>
+                                                    <li><code>Stripe82_od.tar</code></li>
+                                                    <li><code>Stripe82_oi.tar</code></li>
+                                                    <li><code>Stripe82_ow.tar</code></li>
+                                                    <li><code>Stripe82_rd.tar</code></li>
+                                                    <li><code>Stripe82_ri.tar</code></li>
+                                                    <li><code>Stripe82_rw.tar</code></li>
+                                                    <li><code>Stripe82_sd.tar</code></li>
+                                                    <li><code>Stripe82_se.tar</code></li>
+                                                    <li><code>Stripe82_sw.tar</code></li>
+                                                    <li><code>Stripe82_si.tar</code></li>
+                                                    <li><code>Stripe82_sw.tar</code></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                                <ul>
+                                    <li>ptf/
+                                        <ul>
+                                            <li>cfht-w4/
+                                                <ul>
+                                                    <li><code>biases.tar</code></li>
+                                                    <li><code>catalogs.tar</code></li>
+                                                    <li><code>flats.tar</code></li>
+                                                    <li><code>images-original.tar</code></li>
+                                                    <li><code>masks-original.tar</code></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li>results/
+                                <ul>
+                                    <li><code>ptfpipeline.tar</code></li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                    <li><code>cosmos_nvo.tar</code></li>
+                    <li>imaging/
+                        <ul>
+                            <li>cats/
+                                <ul>
+                                    <li><code>imaging_cats_gaia_decals.tar</code></li>
+                                    <li><code>imaging_cats_sdss.tar</code></li>
+                                </ul>
+                            </li>
+                            <li>data/
+                                <ul>
+                                    <li><code>wiyn.tar</code></li>
+                                </ul>
+                            </li>
+                            <li>db/
+                                <ul>
+                                    <li>backup/
+                                        <ul>
+                                            <li><code>desi_dump.20150511.db</code></li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </div><!-- end class="col-12" -->
+        </div><!-- end class="row" -->
+    </div><!-- end class="container" -->
+</body>
+</html>


### PR DESCRIPTION
This PR closes #6.

The backup status is visible at https://portal.nersc.gov/project/desi/collab/backups/.  Please use this PR for additional comments on that page and the infrastructure behind it.

For consideration:

1. Decide what to do with the external directory.  Unless we have a specific future use case in mind for it, it would be more appropriate to list it under the 'Other Backups' section.
2. I propose setting the status of the metadata directory to 'no backups'.  I don't think anyone will be too upset if we lose data in that directory, since it is regenerated every night.  That said, we have not deleted anything from that directory, although older data gets compressed on a regular basis.