### PR TITLE
[WIP] Configure datachallenge/quicklook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ This product contains wrapper scripts on the `HPSSPy`_ package.
 Configuring desiBackup
 ----------------------
 
-desiBackup configuration is provided by the file ``etc/desi.json``.  
+desiBackup configuration is provided by the file ``etc/desi.json``.
 This file is fully described in the
 `HPSSPy configuration document <http://hpsspy.readthedocs.io/en/latest/configuration.html>`_.
 Please be sure to read that document before editing the configuration file.
@@ -51,11 +51,16 @@ raise an exception.
 Change Log
 ----------
 
-0.1.1 (unreleased)
+0.2.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
+* Compatibility with `HPSSPy`_ version 0.5.0 (PR `#11`_).
+* Add configuration or at least placeholders for most of the DESI data tree,
+  and add monitoring script (PR `#8`_).
 * Added Travis test.
-* Compatibility with `HPSSPy` version 0.4.0.
+
+.. _`#11`: https://github.com/desihub/desiBackup/pull/11
+.. _`#8`: https://github.com/desihub/desiBackup/pull/8
 
 0.1.0 (2017-01-23)
 ~~~~~~~~~~~~~~~~~~

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -123,7 +123,7 @@ COMMENTS
 )
 for d in ${sections}; do
     if [[ "${d}" == "gsharing" ]]; then
-        row ${d} 'NO BACKUP' False 'Share data via Globus. The actual data is stored elsewhere.' ${o}
+        row ${d} 'NO BACKUP' False 'Share data via Globus. The actual data are stored elsewhere.' ${o}
     elif [[ "${d}" == "release" ]]; then
         row ${d} 'NO DATA' False 'Empty directory, no results yet!' ${o}
     elif [[ "${d}" == "software" ]]; then

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -61,12 +61,12 @@ function row() {
     echo "${space}    <td class=\"table-${tcls}\"><strong>${s}</strong></td>" >> ${o}
     if [[ "${n}" == "False" ]]; then
         echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">CSV</a></td>" >> ${o}
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">TXT</a></td>" >> ${o}
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">CSV</a></td>" >> ${o}
         echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">JSON</a></td>" >> ${o}
         echo "${space}    <td><a class=\"btn btn-sm btn-outline-light\" role=\"button\" href=\"#\" title=\"Status not run.\">LOG</a></td>" >> ${o}
     else
         echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"disk_files_${d}.csv\" title=\"disk_files_${d}.csv\">CSV</a></td>" >> ${o}
-        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"hpss_files_${d}.txt\" title=\"hpss_files_${d}.txt\">TXT</a></td>" >> ${o}
+        echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"hpss_files_${d}.csv\" title=\"hpss_files_${d}.csv\">CSV</a></td>" >> ${o}
         echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"missing_files_${d}.json\" title=\"missing_files_${d}.json\">JSON</a></td>" >> ${o}
         echo "${space}    <td><a class=\"btn btn-sm btn-outline-primary\" role=\"button\" href=\"missing_files_${d}.log\" title=\"missing_files_${d}.log\">LOG</a></td>" >> ${o}
     fi
@@ -136,14 +136,14 @@ for d in ${sections}; do
             [[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} -D -H -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d} >&2
             missing_from_hpss ${verbose} -D -H -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d} > ${cacheDir}/missing_files_${d}.log 2>&1
         fi
-        hpss_files=$(<${cacheDir}/hpss_files_${d}.txt)
+        hpss_files=$(wc -l ${cacheDir}/hpss_files_${d}.csv)
         missing_files=$(<${cacheDir}/missing_files_${d}.json)
         missing_log=$(grep -v INFO ${cacheDir}/missing_files_${d}.log)
         comment=$(grep "${d}:" <<<"${comments}" | cut -d: -f2)
-        if [[ -z "${hpss_files}" && "${missing_files}" == "{}" ]]; then
+        if [[ "${hpss_files}" == "1" && "${missing_files}" == "{}" ]]; then
             [[ -z "${comment}" ]] && comment='Not configured for backup.'
             row ${d} 'NO CONFIGURATION' True "${comment}" ${o}
-        elif [[ -n "${hpss_files}" && -z "${missing_log}" && "${missing_files}" == "{}" ]]; then
+        elif [[ "${hpss_files}" > "1" && -z "${missing_log}" && "${missing_files}" == "{}" ]]; then
             [[ -z "${comment}" ]] && comment='No missing files found.'
             row ${d} COMPLETE True "${comment}" ${o}
         else

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -136,7 +136,7 @@ for d in ${sections}; do
             [[ -n "${verbose}" ]] && echo missing_from_hpss ${verbose} -D -H -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d} >&2
             missing_from_hpss ${verbose} -D -H -c ${cacheDir} ${DESIBACKUP}/etc/desi.json ${d} > ${cacheDir}/missing_files_${d}.log 2>&1
         fi
-        hpss_files=$(wc -l ${cacheDir}/hpss_files_${d}.csv)
+        hpss_files=$(wc -l ${cacheDir}/hpss_files_${d}.csv | cut -d' ' -f1)
         missing_files=$(<${cacheDir}/missing_files_${d}.json)
         missing_log=$(grep -v INFO ${cacheDir}/missing_files_${d}.log)
         comment=$(grep "${d}:" <<<"${comments}" | cut -d: -f2)

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -123,8 +123,8 @@ COMMENTS
 )
 for d in ${sections}; do
     if [[ "${d}" == "gsharing" ]]; then
-        row ${d} 'NO BACKUP' False 'Share data via Globus. The actual data is stored elsewhere.' ${0}
-    if [[ "${d}" == "release" ]]; then
+        row ${d} 'NO BACKUP' False 'Share data via Globus. The actual data is stored elsewhere.' ${o}
+    elif [[ "${d}" == "release" ]]; then
         row ${d} 'NO DATA' False 'Empty directory, no results yet!' ${o}
     elif [[ "${d}" == "software" ]]; then
         row ${d} 'NO BACKUP' False 'Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.' ${o}

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -121,10 +121,8 @@ sections=$(grep -E '^    "[^"]+":\{' ${DESIBACKUP}/etc/desi.json | \
            grep -v config)
 comments=$(cat <<COMMENTS
 gsharing:Share data via Globus. The actual data are stored elsewhere.
-mocks:<code>lya_forest</code> is missing.
 release:Empty directory, no results yet!
 software:Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.
-spectro:Only partially configured for backup.
 target:Only <code>cmx_files</code> is configured for backup.
 users:The default policy is for the users directory to serve as long-term scratch space, so it is not backed up.
 COMMENTS

--- a/bin/backupStatus.sh
+++ b/bin/backupStatus.sh
@@ -116,16 +116,15 @@ sections=$(grep -E '^    "[^"]+":\{' ${DESIBACKUP}/etc/desi.json | \
            sed -r 's/^    "([^"]+)":\{/\1/' | \
            grep -v config)
 comments=$(cat <<COMMENTS
-datachallenge:<code>quicklook</code> is missing.
 mocks:<code>lya_forest</code> is missing.
 spectro:Only partially configured for backup.
 target:Only <code>cmx_files</code> is configured for backup.
 COMMENTS
 )
 for d in ${sections}; do
-    if [[ "${d}" == "metadata" ]]; then
-        row ${d} 'NO BACKUP' False 'Directory tree scans provided by NERSC. It is more useful to have these backed up off-site.' ${o}
-    elif [[ "${d}" == "release" ]]; then
+    if [[ "${d}" == "gsharing" ]]; then
+        row ${d} 'NO BACKUP' False 'Share data via Globus. The actual data is stored elsewhere.' ${0}
+    if [[ "${d}" == "release" ]]; then
         row ${d} 'NO DATA' False 'Empty directory, no results yet!' ${o}
     elif [[ "${d}" == "software" ]]; then
         row ${d} 'NO BACKUP' False 'Most DESI software is stored elsewhere, and the ultimate backups are the various git and svn repositories.' ${o}

--- a/etc/backupStatus.html
+++ b/etc/backupStatus.html
@@ -40,8 +40,9 @@
                     <p>The "Status" column below is set according to these definitions:</p>
                     <dl class="row">
                         <dt class="col-sm-2 table-danger">NEEDS ATTENTION</dt>
-                        <dd>A problem with existing backups has been detected, or
-                            new data has appeared that should be backed up, but isn't.
+                        <dd class="col-sm-10">A problem with existing backups
+                            has been detected, or new data has appeared that
+                            should be backed up, but isn't.
                             An expert should look at the detailed log files linked
                             to below.</dd>
                         <dt class="col-sm-2 table-danger">NO CONFIGURATION</dt>

--- a/etc/backupStatus.html
+++ b/etc/backupStatus.html
@@ -34,6 +34,8 @@
                         <code>/global/project/projectdirs/desi</code>.
                         On HPSS, the top-level DESI directory is <code>/nersc/projects/desi</code>.
                         Backup files and directories below are relative to this directory.
+                        In some cases, the backups will be automated; in other cases, the
+                        backups will be one-off, "by-hand" backups.
                         See <a href="https://desi.lbl.gov/trac/wiki/Pipeline/Backups">DESI Trac Wiki</a>
                         for more details.
                     </p>
@@ -48,9 +50,7 @@
                         <dt class="col-sm-2 table-danger">NO CONFIGURATION</dt>
                         <dd class="col-sm-10">The Data Management team needs to
                             examine the contents of this directory and determine
-                            the best configuration for backups.  In some cases,
-                            the backups will be automated; in other cases, the
-                            backups will be one-off, "by-hand" backups.</dd>
+                            the best configuration for backups.</dd>
                         <dt class="col-sm-2 table-warning">PARTIAL</dt>
                         <dd class="col-sm-10">The directory is at least partially
                             backed up, through automation or otherwise, but

--- a/etc/backupStatus.html
+++ b/etc/backupStatus.html
@@ -39,22 +39,34 @@
                     </p>
                     <p>The "Status" column below is set according to these definitions:</p>
                     <dl class="row">
+                        <dt class="col-sm-2 table-danger">NEEDS ATTENTION</dt>
+                        <dd>A problem with existing backups has been detected, or
+                            new data has appeared that should be backed up, but isn't.
+                            An expert should look at the detailed log files linked
+                            to below.</dd>
                         <dt class="col-sm-2 table-danger">NO CONFIGURATION</dt>
                         <dd class="col-sm-10">The Data Management team needs to
                             examine the contents of this directory and determine
                             the best configuration for backups.  In some cases,
                             the backups will be automated; in other cases, the
                             backups will be one-off, "by-hand" backups.</dd>
-                        <dt class="col-sm-2 table-warning">IN PROGRESS</dt>
+                        <dt class="col-sm-2 table-warning">PARTIAL</dt>
                         <dd class="col-sm-10">The directory is at least partially
-                            backed up, through automation or otherwise.
-                            Some subdirectories might not be configured for backup.</dd>
+                            backed up, through automation or otherwise, but
+                            some subdirectories are not configured for backup.</dd>
+                        <dt class="col-sm-2 table-warning">IN PROGRESS</dt>
+                        <dd class="col-sm-10">The directory fully configured for
+                            backup, but, right now, some backups are incomplete.</dd>
                         <dt class="col-sm-2 table-success">COMPLETE</dt>
-                        <dd class="col-sm-10">All files on disk are backed up.  In some cases this indicates a completely static data set.</dd>
-                        <dt class="col-sm-2 table-info">NO BACKUP/DATA</dt>
+                        <dd class="col-sm-10">All files on disk that are <em>supposed</em>
+                            to be backed up <em>are</em> backed up.
+                            In some cases this indicates a completely static data set.</dd>
+                        <dt class="col-sm-2 table-info">NO BACKUP</dt>
                         <dd class="col-sm-10">A directory is deliberately not
-                            backed up for a specific reason, or it is an
-                            empty placeholder that may contain data in the future.</dd>
+                            backed up for a specific reason.</dd>
+                        <dt class="col-sm-2 table-info">NO DATA</dt>
+                        <dd class="col-sm-10">The directory is an empty
+                            placeholder that may contain data in the future.</dd>
                     </dl>
                     <table class="table table-bordered">
                         <caption>Last Update: DATE</caption>

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -1,23 +1,23 @@
 {
-    "config":{
+    "__config__":{
         "root":"/global/project/projectdirs/desi",
         "hpss_root":"/nersc/projects/desi",
         "physical_disks":["desi"]
     },
     "cmx":{
-        "exclude":["README"],
+        "__exclude__":["README"],
         "ci":{
         }
     },
     "cosmosim":{
-        "exclude":[],
+        "__exclude__":[],
         "ELG_HOD":{
         },
         "proto_sim":{
         }
     },
     "datachallenge":{
-        "exclude":[],
+        "__exclude__":[],
         "Argonne2015":{
             "Argonne2015/.*$":"Argonne2015.tar"
         },
@@ -66,9 +66,11 @@
             "dr5fiberassign/multiepoch/zcat/([0-9]+)/.*$":"dr5fiberassign/multiepoch/zcat/dr5fiberassign_multiepoch_zcat_\\1.tar"
         },
         "mockobs-18.6":{
-            "mockobs-18.6/.*$":"mockobs-18.6.tar"
+            "mockobs-18\\.6/.*$":"mockobs-18.6.tar"
         },
         "quicklook":{
+            "quicklook/review-19\\.1/redux/exposures/.*$":"quicklook/review-19.1/redux/review-19.1_redux_exposures.tar",
+            "quicklook/review-19\\.1/redux/preproc/.*$":"EXCLUDE"
         },
         "quicksurvey2016":{
             "quicksurvey2016/[^/]+$":"quicksurvey2016/quicksurvey2016_files.tar",
@@ -121,7 +123,7 @@
         }
     },
     "engineering":{
-        "exclude":[],
+        "__exclude__":[],
         "focalplane":{
         },
         "gfa":{
@@ -135,11 +137,18 @@
         "svn_export_focalplane_12302018":{
         }
     },
+    "gsharing":{
+        "__exclude__":[]
+    },
     "metadata":{
-        "exclude":["README.html","scan_README.txt"]
+        "__exclude__":["README.html","scan_README.txt"],
+        "__top__":{
+            "([0-9][0-9][0-9][0-9])-([0-9][0-9])-[0-9][0-9]\\.tlproject[2a]\\.desi\\.txt$":"EXCLUDE",
+            "([0-9][0-9][0-9][0-9])-([0-9][0-9])-[0-9][0-9]\\.tlproject[2a]\\.desi\\.txt\\gz$":"\\1_\\2_files.tar"
+        }
     },
     "mocks":{
-        "exclude":[],
+        "__exclude__":[],
         "DarkSky":{
             "DarkSky/.*$":"DarkSky.tar"
         },
@@ -192,7 +201,7 @@
         }
     },
     "protodesi":{
-        "exclude":["README.html"],
+        "__exclude__":["README.html"],
         "images":{
             "images/(fits|fpc|fpc_engineering_data|fvc|gfa|sti)/.*$":"images/protodesi_images_\\1.tar",
             "images/fpc_analysis/([0-9a-zA-Z_-]+)/.*$":"images/fpc_analysis/protodesi_images_fpc_analysis_\\1.tar"
@@ -202,10 +211,10 @@
         }
     },
     "release":{
-        "exclude":[]
+        "__exclude__":[]
     },
     "science":{
-        "exclude":["README"],
+        "__exclude__":["README"],
         "bgs":{
         },
         "c3":{
@@ -218,10 +227,10 @@
         }
     },
     "software":{
-        "exclude":[]
+        "__exclude__":[]
     },
     "spectro":{
-        "exclude":["README.html"],
+        "__exclude__":["README.html"],
         "StrayLight":{
         },
         "ZemaxSimulation":{
@@ -253,14 +262,14 @@
         }
     },
     "survey":{
-        "exclude":[],
+        "__exclude__":[],
         "planning":{
         },
         "sims":{
         }
     },
     "target":{
-        "exclude":["README.html"],
+        "__exclude__":["README.html"],
         "RF_files":{
         },
         "analysis":{
@@ -288,9 +297,9 @@
         }
     },
     "users":{
-        "exclude":[]
+        "__exclude__":[]
     },
     "www":{
-        "exclude":[]
+        "__exclude__":[]
     }
 }

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -148,7 +148,12 @@
         }
     },
     "mocks":{
-        "__exclude__":["lya_forest/README.html","lya_forest/london/README","lya_forest/saclay/README","lya_forest/saclay/README~"],
+        "__exclude__":["lya_forest/README.html",
+            "lya_forest/london/README",
+            "lya_forest/london/lyasim.log",
+            "lya_forest/saclay/README",
+            "lya_forest/saclay/README~"
+        ],
         "DarkSky":{
             "DarkSky/.*$":"DarkSky.tar"
         },
@@ -183,7 +188,7 @@
             "lya_forest/dr11/.*$":"EXCLUDE",
             "lya_forest/london/(colore_raw|tests|tools)/.*$":"EXCLUDE",
             "lya_forest/london/v[23567]\\.[0-9](\\.[0-9]|)/.*$":"EXCLUDE",
-            "lya_forest/london/v4\\.0\\.[0-9]/.*$":"EXCLUDE",
+            "lya_forest/london/v4\\.0(\\.[0-9]|)/.*$":"EXCLUDE",
             "lya_forest/london/v4\\.2\\.0/[^/]+$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_files.tar",
             "lya_forest/london/v4\\.2\\.0/([0-9]+)/.*$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_\\1.tar",
             "lya_forest/london/v4\\.2\\.0/quick-([0-9.]+)/.*$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_quick-\\1.tar",

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -148,7 +148,7 @@
         }
     },
     "mocks":{
-        "__exclude__":[],
+        "__exclude__":["lya_forest/README.html","lya_forest/london/README","lya_forest/saclay/README","lya_forest/saclay/README~"],
         "DarkSky":{
             "DarkSky/.*$":"DarkSky.tar"
         },
@@ -179,11 +179,20 @@
             "lightcone_galform/.*$":"lightcone_galform.tar"
         },
         "lya_forest":{
+            "lya_forest/develop/.*$":"EXCLUDE",
+            "lya_forest/dr11/.*$":"EXCLUDE",
+            "lya_forest/london/(colore_raw|tests|tools)/.*$":"EXCLUDE",
+            "lya_forest/london/v[23567]\\.[0-9](\\.[0-9]|)/.*$":"EXCLUDE",
+            "lya_forest/london/v4\\.0\\.[0-9]/.*$":"EXCLUDE",
             "lya_forest/london/v4\\.2\\.0/[^/]+$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_files.tar",
             "lya_forest/london/v4\\.2\\.0/([0-9]+)/.*$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_\\1.tar",
             "lya_forest/london/v4\\.2\\.0/quick-([0-9.]+)/.*$":"lya_forest/london/v4.2.0/lya_forest_london_v4.2.0_quick-\\1.tar",
+            "lya_forest/picca/.*$":"EXCLUDE",
+            "lya_forest/saclay/v[23]\\.[0-9]/.*$":"EXCLUDE",
+            "lya_forest/saclay/v4\\.[013]/.*$":"EXCLUDE",
             "lya_forest/saclay/v4\\.2/.*$":"lya_forest/saclay/lya_forest_saclay_v4.2.tar",
-            "lya_forest/saclay/v4\\.4/v4\\.4\\.([0-9]+)/.*$":"lya_forest/saclay/v4.4/lya_forest_saclay_v4.4_v4.4.\\1.tar"
+            "lya_forest/saclay/v4\\.4/v4\\.4\\.([0-9]+)/.*$":"lya_forest/saclay/v4.4/lya_forest_saclay_v4.4_v4.4.\\1.tar",
+            "lya_forest/uncorr/.*$":"EXCLUDE"
         },
         "mws":{
             "mws/(100pc|gaiaDR1quick|small_galaxia|wd|wd100pc)/.*$":"mws/mws_\\1.tar",

--- a/etc/desi.json
+++ b/etc/desi.json
@@ -144,7 +144,7 @@
         "__exclude__":["README.html","scan_README.txt"],
         "__top__":{
             "([0-9][0-9][0-9][0-9])-([0-9][0-9])-[0-9][0-9]\\.tlproject[2a]\\.desi\\.txt$":"EXCLUDE",
-            "([0-9][0-9][0-9][0-9])-([0-9][0-9])-[0-9][0-9]\\.tlproject[2a]\\.desi\\.txt\\gz$":"\\1_\\2_files.tar"
+            "([0-9][0-9][0-9][0-9])-([0-9][0-9])-[0-9][0-9]\\.tlproject[2a]\\.desi\\.txt\\.gz$":"\\1_\\2_files.tar"
         }
     },
     "mocks":{


### PR DESCRIPTION
This PR:

* Closes #10 
* Adds detailed configuration for some `lya_forest` mocks.
* Backups of metadata directory are now supported.
* General update to configuration for compatibility with hpsspy/0.5.0.

I'm still doing tests on this, don't merge yet.

Items for discussion:

- [x] While running tests, I've found some data sets that have files that have changed subsequent to backup.  What policy should we apply to these?